### PR TITLE
Fixed incorrect symbol libraries

### DIFF
--- a/pcb/KiCad/Piezo_Controller.sch
+++ b/pcb/KiCad/Piezo_Controller.sch
@@ -25,7 +25,7 @@ F 3 "" H 4850 4250 50  0001 C CNN
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C14
+L Device:C_Small C14
 U 1 1 5B057937
 P 3300 3550
 F 0 "C14" H 3310 3620 50  0000 L CNN
@@ -118,7 +118,7 @@ F 3 "" H 5700 3700 50  0001 C CNN
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:R R16
+L Device:R R16
 U 1 1 5B057987
 P 6250 4050
 F 0 "R16" V 6330 4050 50  0000 C CNN
@@ -167,7 +167,7 @@ F 5 "Texas Instruments" H 6500 3300 60  0001 C CNN "MFN"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R18
+L Device:R_Small R18
 U 1 1 5B0579A2
 P 7000 3300
 F 0 "R18" H 7030 3320 50  0000 L CNN
@@ -218,7 +218,7 @@ F 5 "OPA1604AIDR" H 3200 3950 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C15
+L Device:C_Small C15
 U 1 1 5B057A08
 P 3300 4350
 F 0 "C15" H 3310 4420 50  0000 L CNN
@@ -235,7 +235,7 @@ Text GLabel 3100 4450 3    60   Input ~ 0
 Text GLabel 1900 6250 0    60   Input ~ 0
 SET
 $Comp
-L device:R_Small R9
+L Device:R_Small R9
 U 1 1 5B057A11
 P 3900 3950
 F 0 "R9" H 3930 3970 50  0000 L CNN
@@ -248,7 +248,7 @@ F 5 "RR0816P-102-D" H 3900 3950 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:R_Small R14
+L Device:R_Small R14
 U 1 1 5B057A18
 P 4900 4950
 F 0 "R14" H 4930 4970 50  0000 L CNN
@@ -265,7 +265,7 @@ Text GLabel 5300 4600 3    60   Input ~ 0
 Text GLabel 5300 3550 1    60   Input ~ 0
 +12V
 $Comp
-L device:R_Small R12
+L Device:R_Small R12
 U 1 1 5B057A35
 P 4500 5100
 F 0 "R12" H 4530 5120 50  0000 L CNN
@@ -302,7 +302,7 @@ F 4 "DNF" H 7700 4600 60  0001 C CNN "Config"
 	-1   0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R23
+L Device:R_Small R23
 U 1 1 5B0591B4
 P 8100 4600
 F 0 "R23" H 8130 4620 50  0000 L CNN
@@ -315,7 +315,7 @@ F 5 "SFR03EZPJ000" H 8100 4600 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:R_Small R25
+L Device:R_Small R25
 U 1 1 5B0591C0
 P 8250 4850
 F 0 "R25" H 8280 4870 50  0000 L CNN
@@ -328,7 +328,7 @@ F 5 "ERJ-3RED1004V" H 8250 4850 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R27
+L Device:R_Small R27
 U 1 1 5B0591C6
 P 8650 3350
 F 0 "R27" H 8680 3370 50  0000 L CNN
@@ -397,7 +397,7 @@ F 4 "DNF" H 10450 3250 60  0001 C CNN "Config"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R29
+L Device:R_Small R29
 U 1 1 5B059205
 P 10050 3250
 F 0 "R29" H 10080 3270 50  0000 L CNN
@@ -460,7 +460,7 @@ Text GLabel 9450 2750 1    60   Input ~ 0
 Text Notes 7700 5450 0    60   ~ 0
 Use as non-inv. amp (R7,R27)\nor divider (R23,R25)\nfor level adjustment.
 $Comp
-L device:R_Small R7
+L Device:R_Small R7
 U 1 1 5B3FA4A8
 P 7950 3700
 F 0 "R7" H 7980 3720 50  0000 L CNN
@@ -494,7 +494,7 @@ F 3 "" H 9550 3250 50  0001 C CNN
 	1    0    0    1   
 $EndComp
 $Comp
-L device:C_Small C10
+L Device:C_Small C10
 U 1 1 5B6D8FE5
 P 2450 4250
 F 0 "C10" H 2460 4320 50  0000 L CNN
@@ -518,7 +518,7 @@ F 3 "" H 2500 6800 50  0001 C CNN
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R11
+L Device:R_Small R11
 U 1 1 5C1A6223
 P 9200 4300
 F 0 "R11" H 9230 4320 50  0000 L CNN
@@ -531,7 +531,7 @@ F 5 "RC1210FR-0749R9L" H 9200 4300 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:C_Small C19
+L Device:C_Small C19
 U 1 1 5C1ADE01
 P 5500 4500
 F 0 "C19" H 5510 4570 50  0000 L CNN
@@ -544,7 +544,7 @@ F 5 "CC0603ZPY5V9BB104" H 5500 4500 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:C_Small C18
+L Device:C_Small C18
 U 1 1 5C1AE145
 P 5500 3650
 F 0 "C18" H 5510 3720 50  0000 L CNN
@@ -557,7 +557,7 @@ F 5 "CC0603ZPY5V9BB104" H 5500 3650 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:C_Small C22
+L Device:C_Small C22
 U 1 1 5C1AE57D
 P 9600 2850
 F 0 "C22" H 9350 2850 50  0000 L CNN
@@ -570,7 +570,7 @@ F 5 "CC0603ZPY5V9BB104" H 9600 2850 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:C_Small C23
+L Device:C_Small C23
 U 1 1 5C1AECC1
 P 9600 3650
 F 0 "C23" H 9450 3600 50  0000 L CNN
@@ -583,7 +583,7 @@ F 5 "CC0603ZPY5V9BB104" H 9600 3650 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:R_Small R10
+L Device:R_Small R10
 U 1 1 5CCF959D
 P 2250 6250
 F 0 "R10" H 2280 6270 50  0000 L CNN
@@ -596,7 +596,7 @@ F 5 "RR0816P-103-D" H 2250 6250 60  0001 C CNN "MFP"
 	0    -1   -1   0   
 $EndComp
 $Comp
-L device:CP C17
+L Device:CP C17
 U 1 1 5CCF9C5E
 P 2500 6550
 F 0 "C17" H 2525 6650 50  0000 L CNN
@@ -609,7 +609,7 @@ F 5 "TCJB106M025R0150" H 2500 6550 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R6
+L Device:R_Small R6
 U 1 1 5CCFABD0
 P 2150 3850
 F 0 "R6" H 2180 3870 50  0000 L CNN
@@ -622,7 +622,7 @@ F 5 "RR0816P-102-D" H 2150 3850 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:R_Small R4
+L Device:R_Small R4
 U 1 1 5CCFCD96
 P 3300 4900
 F 0 "R4" H 3330 4920 50  0000 L CNN
@@ -635,7 +635,7 @@ F 5 "RR0816P-102-D" H 3300 4900 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:R_Small R3
+L Device:R_Small R3
 U 1 1 5CCFCE48
 P 2800 5100
 F 0 "R3" H 2830 5120 50  0000 L CNN
@@ -885,7 +885,7 @@ $EndComp
 Wire Wire Line
 	5700 4500 5700 4600
 $Comp
-L device:R_Small R8
+L Device:R_Small R8
 U 1 1 5E14075D
 P 4200 4250
 F 0 "R8" H 4230 4270 50  0000 L CNN
@@ -949,7 +949,7 @@ F 4 "DNF" H 1650 2500 60  0001 C CNN "Config"
 	-1   0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R20
+L Device:R_Small R20
 U 1 1 5F57DB95
 P 2600 1250
 F 0 "R20" H 2630 1270 50  0000 L CNN
@@ -1007,7 +1007,7 @@ F 4 "DNF" H 5500 2100 60  0001 C CNN "Config"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R26
+L Device:R_Small R26
 U 1 1 5F57DBCA
 P 5100 2100
 F 0 "R26" H 5130 2120 50  0000 L CNN
@@ -1068,7 +1068,7 @@ $EndComp
 Text GLabel 4500 1600 1    60   Input ~ 0
 -12V
 $Comp
-L device:R_Small R17
+L Device:R_Small R17
 U 1 1 5F57DC00
 P 1900 1600
 F 0 "R17" H 1930 1620 50  0000 L CNN
@@ -1102,7 +1102,7 @@ F 3 "" H 4600 2100 50  0001 C CNN
 	1    0    0    1   
 $EndComp
 $Comp
-L device:C_Small C26
+L Device:C_Small C26
 U 1 1 5F57DC2C
 P 4650 1700
 F 0 "C26" H 4400 1700 50  0000 L CNN
@@ -1115,7 +1115,7 @@ F 5 "CC0603ZPY5V9BB104" H 4650 1700 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:C_Small C27
+L Device:C_Small C27
 U 1 1 5F57DC38
 P 4650 2500
 F 0 "C27" H 4500 2450 50  0000 L CNN
@@ -1194,7 +1194,7 @@ Wire Wire Line
 Text GLabel 4500 2500 3    60   Input ~ 0
 +12V
 $Comp
-L device:R_Small R22
+L Device:R_Small R22
 U 1 1 5F5D47A2
 P 3800 1400
 F 0 "R22" H 3830 1420 50  0000 L CNN
@@ -1223,7 +1223,7 @@ Wire Wire Line
 Wire Wire Line
 	3800 1050 4100 1050
 $Comp
-L device:R_Small R24
+L Device:R_Small R24
 U 1 1 5F5E0D9A
 P 4500 1050
 F 0 "R24" H 4530 1070 50  0000 L CNN
@@ -1245,7 +1245,7 @@ Wire Wire Line
 Wire Wire Line
 	4950 1050 4950 2100
 $Comp
-L device:R_Small R19
+L Device:R_Small R19
 U 1 1 5F5EFC6B
 P 2050 2500
 F 0 "R19" H 2080 2520 50  0000 L CNN
@@ -1258,7 +1258,7 @@ F 5 "RR0816P-102-D" H 2050 2500 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:R_Small R21
+L Device:R_Small R21
 U 1 1 5F5F0529
 P 3300 2200
 F 0 "R21" H 3330 2220 50  0000 L CNN
@@ -1271,7 +1271,7 @@ F 5 "RR0816P-102-D" H 3300 2200 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:C_Small C24
+L Device:C_Small C24
 U 1 1 5F617ABC
 P 2200 2750
 F 0 "C24" H 2292 2796 50  0000 L CNN
@@ -1295,7 +1295,7 @@ Connection ~ 3750 2200
 Wire Wire Line
 	3750 2200 4300 2200
 $Comp
-L device:C_Small C25
+L Device:C_Small C25
 U 1 1 5F63A1AA
 P 3750 2600
 F 0 "C25" H 3842 2646 50  0000 L CNN

--- a/pcb/KiCad/Supply_Ref.sch
+++ b/pcb/KiCad/Supply_Ref.sch
@@ -14,7 +14,7 @@ Comment3 ""
 Comment4 ""
 $EndDescr
 $Comp
-L device:C_Small C4
+L Device:C_Small C4
 U 1 1 5B054B90
 P 2050 3450
 F 0 "C4" H 2060 3520 50  0000 L CNN
@@ -44,7 +44,7 @@ Connection ~ 2250 1650
 Wire Wire Line
 	2050 1750 2050 2600
 $Comp
-L device:R_Small R1
+L Device:R_Small R1
 U 1 1 5B054C38
 P 2850 2400
 F 0 "R1" H 2880 2420 50  0000 L CNN
@@ -78,7 +78,7 @@ Connection ~ 2850 2200
 Wire Wire Line
 	2850 2100 2850 2200
 $Comp
-L device:C_Small C9
+L Device:C_Small C9
 U 1 1 5B054C4B
 P 2650 2800
 F 0 "C9" H 2660 2870 50  0000 L CNN
@@ -143,7 +143,7 @@ F 5 "LT8610EMSE#TRPBF" H 3350 6800 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C1
+L Device:C_Small C1
 U 1 1 5B0AE6A5
 P 1500 5450
 F 0 "C1" H 1510 5520 50  0000 L CNN
@@ -156,7 +156,7 @@ F 5 "885012107013" H 1500 5450 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C6
+L Device:C_Small C6
 U 1 1 5B0AE9B6
 P 2600 6150
 F 0 "C6" H 2610 6220 50  0000 L CNN
@@ -169,7 +169,7 @@ F 5 "GRM1885C1H103JA01D" H 2600 6150 60  0001 C CNN "MFP"
 	0    -1   -1   0   
 $EndComp
 $Comp
-L device:C_Small C7
+L Device:C_Small C7
 U 1 1 5B0AEA0F
 P 2600 6350
 F 0 "C7" H 2610 6420 50  0000 L CNN
@@ -182,7 +182,7 @@ F 5 "UMK212B7105KG-T" H 2600 6350 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:C_Small C16
+L Device:C_Small C16
 U 1 1 5B0AEFF1
 P 4400 6500
 F 0 "C16" H 4410 6570 50  0000 L CNN
@@ -195,7 +195,7 @@ F 5 "885012006051" H 4400 6500 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:R_Small R5
+L Device:R_Small R5
 U 1 1 5B0AF358
 P 3150 6800
 F 0 "R5" H 3180 6820 50  0000 L CNN
@@ -208,7 +208,7 @@ F 5 "RR0816P-5232-D-70C" H 3150 6800 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R13
+L Device:R_Small R13
 U 1 1 5B0AF3B3
 P 4050 6800
 F 0 "R13" H 4080 6820 50  0000 L CNN
@@ -221,7 +221,7 @@ F 5 "RR0816P-2433-D-38D" H 4050 6800 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:R_Small R15
+L Device:R_Small R15
 U 1 1 5B0AF408
 P 4400 6150
 F 0 "R15" H 4430 6170 50  0000 L CNN
@@ -234,7 +234,7 @@ F 5 "ERJ-3RED1004V" H 4400 6150 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:L_Small L3
+L Device:L_Small L3
 U 1 1 5B0AF459
 P 4250 5750
 F 0 "L3" H 4280 5790 50  0000 L CNN
@@ -247,7 +247,7 @@ F 5 "MSS1278T-472MLD" H 4250 5750 60  0001 C CNN "MFP"
 	0    1    1    0   
 $EndComp
 $Comp
-L device:L_Small L2
+L Device:L_Small L2
 U 1 1 5B0AFFC6
 P 2150 5300
 F 0 "L2" H 2180 5340 50  0000 L CNN
@@ -260,7 +260,7 @@ F 5 "MSS1278T-472MLD" H 2150 5300 60  0001 C CNN "MFP"
 	0    -1   -1   0   
 $EndComp
 $Comp
-L device:L_Small L1
+L Device:L_Small L1
 U 1 1 5B0B0023
 P 1750 5300
 F 0 "L1" H 1780 5340 50  0000 L CNN
@@ -399,7 +399,7 @@ Wire Wire Line
 	4600 6500 4500 6500
 Connection ~ 4600 6150
 $Comp
-L device:C_Small C20
+L Device:C_Small C20
 U 1 1 5B0B772C
 P 4800 5950
 F 0 "C20" H 4810 6020 50  0000 L CNN
@@ -412,7 +412,7 @@ F 5 "EMK325BJ476MM-P" H 4800 5950 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:RF_Shield_One_Piece J9
+L Device:RF_Shield_One_Piece J9
 U 1 1 5B0D8BF4
 P 5950 6050
 F 0 "J9" H 5950 6250 50  0000 C CNN
@@ -426,7 +426,7 @@ F 6 "DNF" H 5950 6050 60  0001 C CNN "Config"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C8
+L Device:C_Small C8
 U 1 1 5C1A9735
 P 2650 2400
 F 0 "C8" H 2660 2470 50  0000 L CNN
@@ -439,7 +439,7 @@ F 5 "C1206C104K3GEC7210" H 2650 2400 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C21
+L Device:C_Small C21
 U 1 1 5C1A9DA5
 P 7150 1600
 F 0 "C21" H 7160 1670 50  0000 L CNN
@@ -452,7 +452,7 @@ F 5 "C1206C104K3GEC7210" H 7150 1600 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C3
+L Device:C_Small C3
 U 1 1 5C1BB058
 P 2050 1650
 F 0 "C3" H 2060 1720 50  0000 L CNN
@@ -465,7 +465,7 @@ F 5 "GMK325BJ106MN-T" H 2050 1650 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C12
+L Device:C_Small C12
 U 1 1 5C1BB114
 P 4150 1700
 F 0 "C12" H 4160 1770 50  0000 L CNN
@@ -478,7 +478,7 @@ F 5 "GMK325BJ106MN-T" H 4150 1700 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C13
+L Device:C_Small C13
 U 1 1 5C1BB1D1
 P 4150 3450
 F 0 "C13" H 4160 3520 50  0000 L CNN
@@ -491,7 +491,7 @@ F 5 "GMK325BJ106MN-T" H 4150 3450 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C2
+L Device:C_Small C2
 U 1 1 5C1BD28C
 P 1950 5450
 F 0 "C2" H 1960 5520 50  0000 L CNN
@@ -504,7 +504,7 @@ F 5 "885012107013" H 1950 5450 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C5
+L Device:C_Small C5
 U 1 1 5C1BD316
 P 2350 5450
 F 0 "C5" H 2360 5520 50  0000 L CNN
@@ -517,7 +517,7 @@ F 5 "885012107013" H 2350 5450 60  0001 C CNN "MFP"
 	1    0    0    -1  
 $EndComp
 $Comp
-L device:C_Small C11
+L Device:C_Small C11
 U 1 1 5C2275B7
 P 4050 5550
 F 0 "C11" H 4060 5620 50  0000 L CNN
@@ -601,7 +601,7 @@ Connection ~ 7150 1400
 Wire Wire Line
 	8300 1400 8550 1400
 $Comp
-L device:R_Small R2
+L Device:R_Small R2
 U 1 1 5CCF58A1
 P 2850 2800
 F 0 "R2" H 2880 2820 50  0000 L CNN
@@ -748,7 +748,7 @@ Wire Wire Line
 Wire Wire Line
 	7150 1400 7300 1400
 $Comp
-L device:R_POT RV1
+L Device:R_POT RV1
 U 1 1 5D6DA79F
 P 9150 1700
 F 0 "RV1" H 9080 1746 50  0000 R CNN

--- a/pcb/KiCad/sym-lib-table
+++ b/pcb/KiCad/sym-lib-table
@@ -1,9 +1,4 @@
 (sym_lib_table
-  (lib (name power)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/power.lib)(options "")(descr ""))
-  (lib (name device)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/device.lib)(options "")(descr ""))
-  (lib (name 74xx)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/74xx.lib)(options "")(descr ""))
-  (lib (name audio)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/audio.lib)(options "")(descr ""))
-  (lib (name interface)(type Legacy)(uri ${KICAD_SYMBOL_DIR}/interface.lib)(options "")(descr ""))
   (lib (name RedPitaya)(type Legacy)(uri ${KIPRJMOD}/libraries/redpitaya_125-14.lib)(options "")(descr ""))
   (lib (name TexasInstruments)(type Legacy)(uri ${KIPRJMOD}/libraries/Texas_Instruments.lib)(options "")(descr ""))
   (lib (name LinearTechnology)(type Legacy)(uri "${KIPRJMOD}/libraries/Linear Technology.lib")(options "")(descr ""))


### PR DESCRIPTION
The symbol lib **device** does exist (anymore?). It is spelled with a capital D instead.